### PR TITLE
Feat/better missing file message

### DIFF
--- a/autotest.py
+++ b/autotest.py
@@ -63,8 +63,6 @@ def run_autotest():
         )
         return 0
 
-    copy_files_to_temp_directory(args, parameters)
-
     if args.generate_expected_output != "no":
         return generate_expected_output(tests, parameters, args)
 

--- a/autotest.py
+++ b/autotest.py
@@ -19,7 +19,7 @@ if __name__ == "__main__":
 from util import AutotestException
 from command_line_arguments import process_arguments
 from copy_files_to_temp_directory import copy_files_to_temp_directory
-from run_tests import run_tests, generate_expected_output
+from run_tests import run_tests
 from upload_results import run_tests_and_upload_results
 
 
@@ -62,9 +62,6 @@ def run_autotest():
             )
         )
         return 0
-
-    if args.generate_expected_output != "no":
-        return generate_expected_output(tests, parameters, args)
 
     if parameters.get("upload_url", ""):
         return run_tests_and_upload_results(tests, parameters, args)

--- a/autotest.py
+++ b/autotest.py
@@ -19,7 +19,7 @@ if __name__ == "__main__":
 from util import AutotestException
 from command_line_arguments import process_arguments
 from copy_files_to_temp_directory import copy_files_to_temp_directory
-from run_tests import run_tests
+from run_tests import run_tests, generate_expected_output
 from upload_results import run_tests_and_upload_results
 
 
@@ -62,6 +62,11 @@ def run_autotest():
             )
         )
         return 0
+
+    copy_files_to_temp_directory(args, parameters)
+
+    if args.generate_expected_output != "no":
+        return generate_expected_output(tests, parameters, args)
 
     if parameters.get("upload_url", ""):
         return run_tests_and_upload_results(tests, parameters, args)

--- a/copy_files_to_temp_directory.py
+++ b/copy_files_to_temp_directory.py
@@ -5,7 +5,7 @@ from shutil import copy2, copystat
 from util import die
 from termcolor import colored
 
-
+# Returns False if expected files are missing, True otherwise.
 def copy_files_to_temp_directory(args, parameters, file=sys.stdout):
     temp_dir = tempfile.mkdtemp()
     atexit.register(cleanup, temp_dir=temp_dir, args=args)
@@ -22,8 +22,8 @@ def copy_files_to_temp_directory(args, parameters, file=sys.stdout):
     if not result_check_expec["success"]:
         error_msg = "Unable to run tests because "
         error_msg += f"these files were missing: {colored(' '.join(result_check_expec['files_not_found']), 'red')}"
-        print(error_msg, file=file)
-        exit(1)
+        print(error_msg, flush=True, file=file)
+        return False
 
     os.chdir(temp_dir)
 
@@ -33,6 +33,7 @@ def copy_files_to_temp_directory(args, parameters, file=sys.stdout):
     for expected_file in glob.glob("*.expected_*"):
         os.chmod(expected_file, 0o400)
 
+    return True
 
 def fetch_submission(temp_dir, args):
     if args.debug:

--- a/copy_files_to_temp_directory.py
+++ b/copy_files_to_temp_directory.py
@@ -11,12 +11,14 @@ def copy_files_to_temp_directory(args, parameters, file=sys.stdout):
     atexit.register(cleanup, temp_dir=temp_dir, args=args)
     if parameters["supplied_files_directory"]:
         copy_directory(parameters["supplied_files_directory"], temp_dir)
-    
+
     fetch_submission(temp_dir, args)
 
     # check if all expected files are now present.
-    # if not, exit immediately. 
-    result_check_expec = check_expected_files(temp_dir, parameters["files"], parameters["files"].copy())
+    # if not, exit immediately.
+    result_check_expec = check_expected_files(
+        temp_dir, parameters["files"], parameters["files"].copy()
+    )
     if not result_check_expec["success"]:
         error_msg = "Unable to run tests because "
         error_msg += f"these files were missing: {colored(' '.join(result_check_expec['files_not_found']), 'red')}"
@@ -26,10 +28,11 @@ def copy_files_to_temp_directory(args, parameters, file=sys.stdout):
     os.chdir(temp_dir)
 
     # added for COMP1521 shell assignment but probably a good idea generally
-    # os.environ['HOME'] = temp_dir     
+    # os.environ['HOME'] = temp_dir
 
     for expected_file in glob.glob("*.expected_*"):
         os.chmod(expected_file, 0o400)
+
 
 def fetch_submission(temp_dir, args):
     if args.debug:
@@ -190,6 +193,7 @@ def load_embedded_autotest(exercise):
         t.extractall(temp_dir)
     return os.path.join(temp_dir, "tests.txt")
 
+
 def check_expected_files(dir, expected_files, files_not_found):
     for file_ in os.listdir(dir):
         if file_ in expected_files:
@@ -197,6 +201,6 @@ def check_expected_files(dir, expected_files, files_not_found):
         full_pathname = os.path.join(dir, file_)
         if os.path.isdir(full_pathname):
             check_expected_files(full_pathname, expected_files, files_not_found)
-    
+
     success = len(files_not_found) == 0
-    return {"success": success, "files_not_found": files_not_found} 
+    return {"success": success, "files_not_found": files_not_found}

--- a/copy_files_to_temp_directory.py
+++ b/copy_files_to_temp_directory.py
@@ -35,6 +35,7 @@ def copy_files_to_temp_directory(args, parameters, file=sys.stdout):
 
     return True
 
+
 def fetch_submission(temp_dir, args):
     if args.debug:
         print(f"fetch_submission({temp_dir})", file=sys.stderr)

--- a/copy_files_to_temp_directory.py
+++ b/copy_files_to_temp_directory.py
@@ -21,15 +21,20 @@ def copy_files_to_temp_directory(args, parameters, file=sys.stdout):
     temp_dir = tempfile.mkdtemp()
     atexit.register(cleanup, temp_dir=temp_dir, args=args)
     if parameters["supplied_files_directory"]:
-        result_supplied_dir = copy_directory(parameters["supplied_files_directory"], temp_dir, parameters["files"], parameters["files"].copy())
+        result_supplied_dir = copy_directory(
+            parameters["supplied_files_directory"],
+            temp_dir,
+            parameters["files"],
+            parameters["files"].copy(),
+        )
         # if not result["success"]:
         #     parameters["missing_files"]["exist"] = True
         #     parameters["missing_files"]["files"] = result["files_not_found"]
         #     print("didn't find these??", result["files_not_found"])
-            # error_msg = "Unable to run tests because "
-            # error_msg += f"these files were missing: {' '.join(result['files_not_found'])}"
-            # print(error_msg)
-            # exit(1)
+        # error_msg = "Unable to run tests because "
+        # error_msg += f"these files were missing: {' '.join(result['files_not_found'])}"
+        # print(error_msg)
+        # exit(1)
     result_fetch_sub = fetch_submission(temp_dir, args, parameters)
     os.chdir(temp_dir)
 
@@ -39,8 +44,9 @@ def copy_files_to_temp_directory(args, parameters, file=sys.stdout):
     for expected_file in glob.glob("*.expected_*"):
         os.chmod(expected_file, 0o400)
 
-# TODO: allow this function to detect if specified 
-# required files for the autotest 
+
+# TODO: allow this function to detect if specified
+# required files for the autotest
 # have not been supplied
 def fetch_submission(temp_dir, args, parameters):
     if args.debug:
@@ -57,7 +63,9 @@ def fetch_submission(temp_dir, args, parameters):
                 print_command=args.debug,
             )
     elif args.directory:
-        copy_directory(args.directory, temp_dir, parameters["files"], parameters["files"].copy())
+        copy_directory(
+            args.directory, temp_dir, parameters["files"], parameters["files"].copy()
+        )
     elif args.git:
         os.chdir(temp_dir)
         if args.commit:
@@ -137,9 +145,11 @@ def fetch_submission(temp_dir, args, parameters):
 # exit_status == 1 -> 1 or more tests failed
 # exit_status >- 2, internal error - testing not completed
 
-# return values -> positive/0 == 
+# return values -> positive/0 ==
 # -1 == Not all values found
-def copy_directory(src, dst, expected_files=[], files_not_found=[], symlinks=False, ignore=None):
+def copy_directory(
+    src, dst, expected_files=[], files_not_found=[], symlinks=False, ignore=None
+):
     names = os.listdir(src)
     if ignore is not None:
         ignored_names = ignore(src, names)
@@ -153,7 +163,7 @@ def copy_directory(src, dst, expected_files=[], files_not_found=[], symlinks=Fal
             copystat(src, dst)
         except (WindowsError, OSError):
             pass
-    
+
     for name in names:
         if name in ignored_names:
             continue
@@ -170,7 +180,9 @@ def copy_directory(src, dst, expected_files=[], files_not_found=[], symlinks=Fal
                 linkto = os.readlink(srcname)
                 os.symlink(linkto, dstname)
             elif os.path.isdir(srcname):
-                result = copy_directory(srcname, dstname, expected_files, files_not_found, symlinks, ignore)
+                result = copy_directory(
+                    srcname, dstname, expected_files, files_not_found, symlinks, ignore
+                )
                 files_not_found = result["files_not_found"]
             else:
                 copy2(srcname, dstname)
@@ -179,8 +191,7 @@ def copy_directory(src, dst, expected_files=[], files_not_found=[], symlinks=Fal
             print("Warning:", why, file=sys.stderr)
 
     success = len(files_not_found) == 0
-    return {"success": success, "files_not_found": files_not_found} 
-    
+    return {"success": success, "files_not_found": files_not_found}
 
 
 def cleanup(temp_dir=None, args={}):

--- a/copy_files_to_temp_directory.py
+++ b/copy_files_to_temp_directory.py
@@ -19,11 +19,9 @@ def copy_files_to_temp_directory(args, parameters, file=sys.stdout):
     result_check_expec = check_expected_files(
         temp_dir, parameters["files"], parameters["files"].copy()
     )
+
     if not result_check_expec["success"]:
-        error_msg = "Unable to run tests because "
-        error_msg += f"these files were missing: {colored(' '.join(result_check_expec['files_not_found']), 'red')}"
-        print(error_msg, flush=True, file=file)
-        return False
+        parameters["missing_files"] = result_check_expec['files_not_found']
 
     os.chdir(temp_dir)
 
@@ -32,8 +30,6 @@ def copy_files_to_temp_directory(args, parameters, file=sys.stdout):
 
     for expected_file in glob.glob("*.expected_*"):
         os.chmod(expected_file, 0o400)
-
-    return True
 
 
 def fetch_submission(temp_dir, args):

--- a/copy_files_to_temp_directory.py
+++ b/copy_files_to_temp_directory.py
@@ -21,7 +21,7 @@ def copy_files_to_temp_directory(args, parameters, file=sys.stdout):
     )
 
     if not result_check_expec["success"]:
-        parameters["missing_files"] = result_check_expec['files_not_found']
+        parameters["missing_files"] = result_check_expec["files_not_found"]
 
     os.chdir(temp_dir)
 

--- a/parameter_descriptions.py
+++ b/parameter_descriptions.py
@@ -773,14 +773,6 @@ PARAMETER_LIST += [
 
 		""",
     ),
-    Parameter(
-        "missing_files",
-        default={"exist": False},
-        description="""
-			If there are missing files, do not run any tests.
-            Workaround to enable run_tests_and_upload_results() to work properly.
-		""",
-    ),
     """
 		### Parameters specifying resource limits for test
 		

--- a/parameter_descriptions.py
+++ b/parameter_descriptions.py
@@ -773,6 +773,15 @@ PARAMETER_LIST += [
 
 		""",
     ),
+    Parameter(
+        "missing_files",
+        default={"exist": False},
+        description="""
+			If there are missing files, do not run any tests.
+            Workaround to enable run_tests_and_upload_results() to work properly.
+		""",
+    ),
+
     """
 		### Parameters specifying resource limits for test
 		

--- a/parameter_descriptions.py
+++ b/parameter_descriptions.py
@@ -774,13 +774,13 @@ PARAMETER_LIST += [
 		""",
     ),
     Parameter(
-         "missing_files",
-         default=[],
-         description="""
+        "missing_files",
+        default=[],
+        description="""
  			List of any files missing that are required for all tests.
             Is filled in by the `copy_files_to_temp_directory` function.
  		""",
-     ),
+    ),
     """
 		### Parameters specifying resource limits for test
 		

--- a/parameter_descriptions.py
+++ b/parameter_descriptions.py
@@ -773,6 +773,14 @@ PARAMETER_LIST += [
 
 		""",
     ),
+    Parameter(
+         "missing_files",
+         default=[],
+         description="""
+ 			List of any files missing that are required for all tests.
+            Is filled in by the `copy_files_to_temp_directory` function.
+ 		""",
+     ),
     """
 		### Parameters specifying resource limits for test
 		

--- a/parameter_descriptions.py
+++ b/parameter_descriptions.py
@@ -781,7 +781,6 @@ PARAMETER_LIST += [
             Workaround to enable run_tests_and_upload_results() to work properly.
 		""",
     ),
-
     """
 		### Parameters specifying resource limits for test
 		

--- a/run_tests.py
+++ b/run_tests.py
@@ -26,7 +26,7 @@ def run_tests(
         return 1
 
     if args.generate_expected_output != "no":
-        return generate_expected_output(tests, global_parameters, args)
+        generate_expected_output(tests, global_parameters, args)
 
     debug = global_parameters["debug"]
     colored = (

--- a/run_tests.py
+++ b/run_tests.py
@@ -22,12 +22,6 @@ def run_tests(
     file=sys.stdout,
 ) -> int:
 
-    if not copy_files_to_temp_directory(args, global_parameters, file=file):
-        return 1
-
-    if args.generate_expected_output != "no":
-        generate_expected_output(tests, global_parameters, args)
-
     debug = global_parameters["debug"]
     colored = (
         termcolor_colored
@@ -43,6 +37,14 @@ def run_tests(
         die(f"autotest not available for {args.exercise}")
     if not args.labels:
         die("nothing to test")
+
+    # If missing files exist, abort function and return 1
+    missing_files = global_parameters["missing_files"]
+    if len(missing_files):
+        error_msg = "Unable to run tests because "
+        error_msg += f"these files were missing: {colored(' '.join(missing_files), 'red')}"
+        print(error_msg, flush=True, file=file)
+        return 1
 
     results = []
     for (label, test) in tests.items():

--- a/run_tests.py
+++ b/run_tests.py
@@ -37,6 +37,11 @@ def run_tests(
     if not args.labels:
         die("nothing to test")
 
+    # TODO: add proper error message
+    if global_parameters["missing_files"]["exist"]:
+        print("Missing files")
+        exit(1)
+
     results = []
     for (label, test) in tests.items():
         if label not in args.labels:
@@ -67,7 +72,7 @@ def run_tests(
     return 1 if n_tests_failed + n_tests_not_run else 0
 
 
-# TO-DO: provide stricter type for previous_errors
+# TODO: provide stricter type for previous_errors
 def run_one_test(
     test: _Test, args: Namespace, file=sys.stdout, previous_errors: Dict[str, Any] = {}
 ) -> int:

--- a/run_tests.py
+++ b/run_tests.py
@@ -25,6 +25,9 @@ def run_tests(
     if not copy_files_to_temp_directory(args, global_parameters, file=file):
         return 1
 
+    if args.generate_expected_output != "no":
+        return generate_expected_output(tests, global_parameters, args)
+
     debug = global_parameters["debug"]
     colored = (
         termcolor_colored

--- a/run_tests.py
+++ b/run_tests.py
@@ -22,7 +22,8 @@ def run_tests(
     file=sys.stdout,
 ) -> int:
 
-    copy_files_to_temp_directory(args, global_parameters, file=file)
+    if not copy_files_to_temp_directory(args, global_parameters, file=file):
+        return 1
 
     debug = global_parameters["debug"]
     colored = (

--- a/run_tests.py
+++ b/run_tests.py
@@ -4,6 +4,7 @@
 import copy, glob, io, os, re, subprocess, sys
 from termcolor import colored as termcolor_colored
 from parse_test_specification import output_file_without_parameters
+from copy_files_to_temp_directory import copy_files_to_temp_directory
 from util import die
 
 # necessary for typehinting
@@ -21,6 +22,8 @@ def run_tests(
     file=sys.stdout,
 ) -> int:
 
+    copy_files_to_temp_directory(args, global_parameters, file=file)
+
     debug = global_parameters["debug"]
     colored = (
         termcolor_colored
@@ -36,11 +39,6 @@ def run_tests(
         die(f"autotest not available for {args.exercise}")
     if not args.labels:
         die("nothing to test")
-
-    # TODO: add proper error message
-    if global_parameters["missing_files"]["exist"]:
-        print("Missing files")
-        exit(1)
 
     results = []
     for (label, test) in tests.items():

--- a/run_tests.py
+++ b/run_tests.py
@@ -42,7 +42,9 @@ def run_tests(
     missing_files = global_parameters["missing_files"]
     if len(missing_files):
         error_msg = "Unable to run tests because "
-        error_msg += f"these files were missing: {colored(' '.join(missing_files), 'red')}"
+        error_msg += (
+            f"these files were missing: {colored(' '.join(missing_files), 'red')}"
+        )
         print(error_msg, flush=True, file=file)
         return 1
 


### PR DESCRIPTION
Changed the behaviour of autotest when required files (that are required by every test) are missing. Now if any of these files are missing, run_tests() will return 1 immediately rather than trying to run each individual test. Checks are still performed when each test runs to see if any files are missing, since files can also be specified per-test if users wish to do this. This has been implemented so that it shouldn't interfere with upload_results.py. It did involve, however, moving the call to copy_files_to_temp_directory to be the first line of code in run_tests().