### PR TITLE
fix `link_program()` so that compilers=[] works

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -339,7 +339,7 @@ def link_program(
     if not os.path.exists(program):
         if debug > 3:
             print("link_program - before link command")
-            subprocess.call("pwd",   shell=True)
+            subprocess.call("pwd", shell=True)
             subprocess.call("ls -l", shell=True)
             print(f"os.symlink({unique_program_name}, {program})", file=sys.stderr)
 
@@ -348,7 +348,7 @@ def link_program(
 
         if debug > 3:
             print("link_program - after link command")
-            subprocess.call("pwd",   shell=True)
+            subprocess.call("pwd", shell=True)
             subprocess.call("ls -l", shell=True)
 
     linked_program[program] = unique_program_name


### PR DESCRIPTION
`link_program()` wasn't actually doing anything as it was creating hard links but checking for symbolic links.
`link_program()` now creates symbolic links.

But this then caused an issue with `run_compilers()` as the link was then being renamed to be it's own target.
So `run_compilers()` now doesn't rename symbolic links.

This shouldn't break anything as the only time symbolic links exist is if they have already been created by a previous call to `run_compilers()` and `link_program()` and therefore `run_support_command()` returned a cached result and didn't change anything anyway.