### PR TITLE
Dylan/patches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,492 @@
-__pycache__
-.mypy_cache
+### Linux ###
+*~
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+### macOS ###
+# General
 .DS_Store
-a.out
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### macOS Patch ###
+# iCloud generated files
+*.icloud
+
+### Windows ###
+# Windows thumbnail cache files
+Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+### Emacs ###
+# -*- mode: gitignore; -*-
+*~
+\#*\#
+/.emacs.desktop
+/.emacs.desktop.lock
+*.elc
+auto-save-list
+tramp
+.\#*
+
+# Org-mode
+.org-id-locations
+*_archive
+
+# flymake-mode
+*_flymake.*
+
+# eshell files
+/eshell/history
+/eshell/lastdir
+
+# elpa packages
+/elpa/
+
+# reftex files
+*.rel
+
+# AUCTeX auto folder
+/auto/
+
+# cask packages
+.cask/
+dist/
+
+# Flycheck
+flycheck_*.el
+
+# server auth directory
+/server/
+
+# projectiles files
+.projectile
+
+# directory configuration
+.dir-locals.el
+
+# network security
+/network-security.data
+
+
+### PyCharm ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# AWS User-specific
+.idea/**/aws.xml
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# SonarLint plugin
+.idea/sonarlint/
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+
+### PyCharm Patch ###
+# Comment Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-215987721
+
+# *.iml
+# modules.xml
+# .idea/misc.xml
+# *.ipr
+
+# Sonarlint plugin
+# https://plugins.jetbrains.com/plugin/7973-sonarlint
+.idea/**/sonarlint/
+
+# SonarQube Plugin
+# https://plugins.jetbrains.com/plugin/7238-sonarqube-community-plugin
+.idea/**/sonarIssues.xml
+
+# Markdown Navigator plugin
+# https://plugins.jetbrains.com/plugin/7896-markdown-navigator-enhanced
+.idea/**/markdown-navigator.xml
+.idea/**/markdown-navigator-enh.xml
+.idea/**/markdown-navigator/
+
+# Cache file creation bug
+# See https://youtrack.jetbrains.com/issue/JBR-2257
+.idea/$CACHE_FILE$
+
+# CodeStream plugin
+# https://plugins.jetbrains.com/plugin/12206-codestream
+.idea/codestream.xml
+
+# Azure Toolkit for IntelliJ plugin
+# https://plugins.jetbrains.com/plugin/8053-azure-toolkit-for-intellij
+.idea/**/azureSettings.xml
+
+### Vim ###
+# Swap
+[._]*.s[a-v][a-z]
+!*.svg  # comment out if you don't need vector files
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]
+
+# Session
+Session.vim
+Sessionx.vim
+
+# Temporary
+.netrwhist
+# Auto-generated tag files
+tags
+# Persistent undo
+[._]*.un~
+
+### VisualStudioCode ###
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+
+# Local History for Visual Studio Code
+.history/
+
+# Built Visual Studio Code Extensions
+*.vsix
+
+### VisualStudioCode Patch ###
+# Ignore all local history of files
+.history
+.ionide
+
+# Support for Project snippet scope
+.vscode/*.code-snippets
+
+# Ignore code-workspaces
+*.code-workspace
+
+### C ###
+# Prerequisites
+*.d
+
+# Object files
 *.o
-core
-*.deb
-*.rpm
-*.orig
-*tmp*
+*.ko
+*.obj
+*.elf
+
+# Linker output
+*.ilk
+*.map
+*.exp
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Libraries
+*.lib
+*.a
+*.la
+*.lo
+
+# Shared objects (inc. Windows DLLs)
+*.dll
+*.so
+*.so.*
+*.dylib
+
+# Executables
+*.exe
+*.out
+*.app
+*.i*86
+*.x86_64
+*.hex
+
+# Debug files
+*.dSYM/
+*.su
+*.idb
+*.pdb
+
+# Kernel Module Compile Results
+*.mod*
+*.cmd
+.tmp_versions/
+modules.order
+Module.symvers
+Mkfile.old
+dkms.conf
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
 
 # don't accidentally add random test files to repo
 /*.c

--- a/parameter_descriptions.py
+++ b/parameter_descriptions.py
@@ -998,16 +998,9 @@ PARAMETER_LIST += [
 def default_description(parameters):
     command = parameters["command"]
     if isinstance(command, list):
-        return " ".join(drepr(p) for p in command)
+        return " ".join(p for p in command)
     else:
-        return drepr(command)
-
-
-def drepr(s):
-    if isinstance(s, str) and s.isascii() and s.isprintable() and " " not in s:
-        return s
-    else:
-        return repr(s)
+        return command
 
 
 PARAMETER_LIST += [
@@ -1036,7 +1029,7 @@ PARAMETER_LIST += [
         "show_diff",
         default=True,
         description="""
-            If true, a description of the difference between expected output  is included in a test failure explanation.
+            If true, a description of the difference between expected output is included in a test failure explanation.
         """,
     ),
     Parameter(
@@ -1050,7 +1043,7 @@ PARAMETER_LIST += [
         "show_reproduce_command",
         default=True,
         description="""
-            If  true the command to reproduce the test is included  in a test failure explanation
+            If true the command to reproduce the test is included in a test failure explanation
         """,
     ),
     Parameter(
@@ -1064,7 +1057,7 @@ PARAMETER_LIST += [
         "show_stdin",
         default=True,
         description="""
-            If  true the stdin is included  in a test failure explanation
+            If true the stdin is included in a test failure explanation
         """,
     ),
     Parameter(
@@ -1098,6 +1091,36 @@ PARAMETER_LIST += [
         description="""
             If true semicolons are not replaced with newlines in the command to reproduce the test if it is included  in a test failure explanation.<br>
             Likely to be replaced with improved controls.
+        """,
+    ),
+    Parameter(
+        "squash_repeated",
+        default=True,
+        description="""
+            If multiple tests produce the same output, only show the first one.
+            Each subsequent test is prints a message saying what it is a duplicate of.
+            Eg.
+            Test 10 (./prog) - failed (errors - same as Test 3)
+        """,
+    ),
+    Parameter(
+        "show_squashed_input",
+        default=False,
+        description="""
+            If true the input for a test is shown even if the test would otherwise be squashed.
+            Note that show_stdin must also be true for the input to be shown.
+            Eg.
+            Test 10 (./prog) - failed (incorrect output - same as Test 3)
+            The input for this test was:
+            ...
+        """,
+    ),
+    Parameter(
+        "show_squashed_reproduce_command",
+        default=False,
+        description="""
+            If true the reproduce command for a test is shown even if the test would otherwise be squashed.
+            Note that show_reproduce_command must also be true for the reproduce command to be shown.
         """,
     ),
 ]
@@ -1277,9 +1300,15 @@ PARAMETER_ALIASES = {
     "use_dcc_output_checking": "dcc_output_checking",
     "cpu": "max_cpu_seconds",
     "max_cpu": "max_cpu_seconds",
+    "wall": "max_real_seconds",
+    "max_wall": "max_real_seconds",
     "max_wall_clock": "max_real_seconds",
+    "real": "max_real_seconds",
+    "max_real": "max_real_seconds",
     "timeout": "max_real_seconds",
     "colorise_output": "colorize_output",
+    "colourise_output": "colorize_output",
+    "colourize_output": "colorize_output",
 }
 
 

--- a/parameter_descriptions.py
+++ b/parameter_descriptions.py
@@ -998,7 +998,7 @@ PARAMETER_LIST += [
 def default_description(parameters):
     command = parameters["command"]
     if isinstance(command, list):
-        return " ".join(p for p in command)
+        return " ".join(command)
     else:
         return command
 

--- a/run_test.py
+++ b/run_test.py
@@ -250,7 +250,14 @@ class _Test:
             n_input_lines = std_input.count("\n")
 
         if self.parameters["show_stdin"]:
-            if unicode_stdin and std_input and (n_input_lines < self.parameters["max_lines_shown"] or self.parameters["show_all_lines"]):
+            if (
+                unicode_stdin
+                and std_input
+                and (
+                    n_input_lines < self.parameters["max_lines_shown"]
+                    or self.parameters["show_all_lines"]
+                )
+            ):
                 self.stdin_explanation += (
                     f"\nThe input for this test was:\n{colored(std_input, 'yellow')}\n"
                 )

--- a/run_tests.py
+++ b/run_tests.py
@@ -225,7 +225,10 @@ def run_one_test(
         )
         if parameters["show_squashed_input"] and stdin_explanation:
             print(stdin_explanation, flush=True, file=file, end="")
-        if parameters["show_squashed_reproduce_command"] and reproduce_command_explanation:
+        if (
+            parameters["show_squashed_reproduce_command"]
+            and reproduce_command_explanation
+        ):
             print(reproduce_command_explanation, flush=True, file=file, end="")
     else:
         print(
@@ -562,9 +565,7 @@ def generate_expected_output(
     format = re.sub(r"\W", "", format)
 
     if format not in ["inline", "inlined", "multiline"]:
-        raise ValueError(
-            f"invalid format {format} for --generate-expected-output"
-        )
+        raise ValueError(f"invalid format {format} for --generate-expected-output")
 
     # print test specification with generated expected output to stdout
     if method in ["stdout", "dump", "print", "echo", "show", "display"]:
@@ -612,7 +613,9 @@ def print_tests_and_expected_output(
     print_expected_output(tests, args, file, format)
 
 
-def print_expected_output(tests: Dict[str, _Test], args: Namespace, file, format: str) -> None:
+def print_expected_output(
+    tests: Dict[str, _Test], args: Namespace, file, format: str
+) -> None:
     # ignore output from tests
     with open(os.devnull, "w", encoding="utf-8") as dev_null:
         for (label, test) in tests.items():
@@ -631,12 +634,20 @@ def print_expected_output(tests: Dict[str, _Test], args: Namespace, file, format
                     print(f"{label} expected_stderr={repr(test.stderr)}", file=file)
             else:
                 if test.stdout:
-                    trailing_newline = test.stdout[-1] == '\n'
-                    stdout = '\n'.join(list(map(lambda line: repr(line)[1:-1], test.stdout.splitlines()))) + ('\n' if trailing_newline else '')
+                    trailing_newline = test.stdout[-1] == "\n"
+                    stdout = "\n".join(
+                        list(
+                            map(lambda line: repr(line)[1:-1], test.stdout.splitlines())
+                        )
+                    ) + ("\n" if trailing_newline else "")
                     print(f'{label} expected_stdout="""\\\n{stdout}"""', file=file)
                     print(file=file)
                 if test.stderr:
-                    trailing_newline = test.stderr[-1] == '\n'
-                    stderr = '\n'.join(list(map(lambda line: repr(line)[1:-1], test.stderr.splitlines()))) + ('\n' if trailing_newline else '')
+                    trailing_newline = test.stderr[-1] == "\n"
+                    stderr = "\n".join(
+                        list(
+                            map(lambda line: repr(line)[1:-1], test.stderr.splitlines())
+                        )
+                    ) + ("\n" if trailing_newline else "")
                     print(f'{label} expected_stderr="""\\\n{stderr}"""', file=file)
                     print(file=file)

--- a/run_tests.py
+++ b/run_tests.py
@@ -2,7 +2,6 @@
 # This code needs extensive revision.
 
 import copy, glob, io, os, re, subprocess, sys
-from statistics import median
 from termcolor import colored as termcolor_colored
 from parse_test_specification import output_file_without_parameters
 from util import die

--- a/run_tests.py
+++ b/run_tests.py
@@ -2,6 +2,7 @@
 # This code needs extensive revision.
 
 import copy, glob, io, os, re, subprocess, sys
+from statistics import median
 from termcolor import colored as termcolor_colored
 from parse_test_specification import output_file_without_parameters
 from util import die
@@ -178,6 +179,7 @@ def run_one_test(
             compile_command_str = " ".join(compile_command)
         else:
             compile_command_str = compile_command
+
         if not parameters["compiler_args"]:
             compile_command_str += " " + " ".join(test_files)
 
@@ -208,9 +210,11 @@ def run_one_test(
         individual_test = failed_individual_tests[0]
 
     long_explanation = individual_test.get_long_explanation()
+    stdin_explanation = individual_test.get_stdin_explanation()
+    reproduce_command_explanation = individual_test.get_reproduce_command_explanation()
     # remove hexadecimal constants
     reduced_long_explanation = re.sub(r"0x[0-9a-f]+", "", long_explanation, flags=re.I)
-    if reduced_long_explanation in previous_errors:
+    if parameters["squash_repeated"] and reduced_long_explanation in previous_errors:
         print(
             colored("failed", "red"),
             "({} - same as Test {})".format(
@@ -220,6 +224,10 @@ def run_one_test(
             flush=True,
             file=file,
         )
+        if parameters["show_squashed_input"] and stdin_explanation:
+            print(stdin_explanation, flush=True, file=file, end="")
+        if parameters["show_squashed_reproduce_command"] and reproduce_command_explanation:
+            print(reproduce_command_explanation, flush=True, file=file, end="")
     else:
         print(
             colored("failed", "red"),
@@ -227,8 +235,11 @@ def run_one_test(
             file=file,
         )
         if long_explanation:
-            # print(file=file)
             print(long_explanation, flush=True, file=file, end="")
+        if stdin_explanation:
+            print(stdin_explanation, flush=True, file=file, end="")
+        if reproduce_command_explanation:
+            print(reproduce_command_explanation, flush=True, file=file, end="")
         previous_errors.setdefault(reduced_long_explanation, label)
 
     return 0
@@ -543,33 +554,50 @@ def generate_expected_output(
     generate expected output for tests from supplied solution
     """
 
+    try:
+        method, format = args.generate_expected_output.split(":")
+    except ValueError:
+        method, format = args.generate_expected_output, "inlined"
+
+    method = re.sub(r"\W", "", method)
+    format = re.sub(r"\W", "", format)
+
+    if format not in ["inline", "inlined", "multiline"]:
+        raise ValueError(
+            f"invalid format {format} for --generate-expected-output"
+        )
+
     # print test specification with generated expected output to stdout
-    if args.generate_expected_output == "stdout":
-        print_tests_and_expected_output(tests, args, sys.stdout)
+    if method in ["stdout", "dump", "print", "echo", "show", "display"]:
+        print_tests_and_expected_output(tests, args, sys.stdout, format)
+        return
+
+    if method in ["update", "inplace", "replace", "overwrite", "write"]:
+        # update test specification file in place with generated expected output
+        # file might temporarily exist with partial contents but
+        # write is small & this avoids handling issues with permissions and symlinks using a rename
+        path = args.test_specification_pathname
+        output = io.StringIO()
+        print_tests_and_expected_output(tests, args, output, format)
+        new_contents = output.getvalue()
+        output.close()
+        with open(path, encoding="utf-8") as f:
+            old_contents = f.read()
+        if old_contents != new_contents:
+            with open(path, "w", encoding="utf-8") as g:
+                g.write(new_contents)
         return
 
     # print only generated expected output
-    if args.generate_expected_output != "update":
-        print_expected_output(tests, args, sys.stdout)
+    if method in ["generated"]:
+        print_expected_output(tests, args, sys.stdout, format)
         return
 
-    # update test specification file in place with generated expected output
-    # file might temporarily exist with partial contents but
-    # write is small & this avoids handling issues with permissions and symlinks using a rename
-    path = args.test_specification_pathname
-    output = io.StringIO()
-    print_tests_and_expected_output(tests, args, output)
-    new_contents = output.getvalue()
-    output.close()
-    with open(path, encoding="utf-8") as f:
-        old_contents = f.read()
-    if old_contents != new_contents:
-        with open(path, "w", encoding="utf-8") as g:
-            g.write(new_contents)
+    raise ValueError(f"invalid method {method} for --generate-expected-output")
 
 
 def print_tests_and_expected_output(
-    tests: Dict[str, _Test], args: Namespace, file
+    tests: Dict[str, _Test], args: Namespace, file, format: str
 ) -> None:
     output_file_without_parameters(
         args.test_specification_pathname,
@@ -579,13 +607,13 @@ def print_tests_and_expected_output(
         file=file,
     )
     print(
-        f"### generated by: autotest --generate_expected_output - see {REPO}",
+        f"\n### generated by: autotest --generate_expected_output - see {REPO}\n",
         file=file,
     )
-    print_expected_output(tests, args, file)
+    print_expected_output(tests, args, file, format)
 
 
-def print_expected_output(tests: Dict[str, _Test], args: Namespace, file) -> None:
+def print_expected_output(tests: Dict[str, _Test], args: Namespace, file, format: str) -> None:
     # ignore output from tests
     with open(os.devnull, "w", encoding="utf-8") as dev_null:
         for (label, test) in tests.items():
@@ -596,7 +624,20 @@ def print_expected_output(tests: Dict[str, _Test], args: Namespace, file) -> Non
             run_one_test(test, file=dev_null)
             if not hasattr(test, "stdout"):
                 die(f"Test {label} could not be run")
-            if test.stdout:
-                print(f"{label} expected_stdout={repr(test.stdout)}", file=file)
-            if test.stderr:
-                print(f"{label} expected_stdout={repr(test.stderr)}", file=file)
+
+            if format in ["inline", "inlined"]:
+                if test.stdout:
+                    print(f"{label} expected_stdout={repr(test.stdout)}", file=file)
+                if test.stderr:
+                    print(f"{label} expected_stderr={repr(test.stderr)}", file=file)
+            else:
+                if test.stdout:
+                    trailing_newline = test.stdout[-1] == '\n'
+                    stdout = '\n'.join(list(map(lambda line: repr(line)[1:-1], test.stdout.splitlines()))) + ('\n' if trailing_newline else '')
+                    print(f'{label} expected_stdout="""\\\n{stdout}"""', file=file)
+                    print(file=file)
+                if test.stderr:
+                    trailing_newline = test.stderr[-1] == '\n'
+                    stderr = '\n'.join(list(map(lambda line: repr(line)[1:-1], test.stderr.splitlines()))) + ('\n' if trailing_newline else '')
+                    print(f'{label} expected_stderr="""\\\n{stderr}"""', file=file)
+                    print(file=file)


### PR DESCRIPTION
Fixes:
- Don't display the name of the program at the start of the reproduce command
- Create expected_stderr when --generate_expected_output produces output stderr
- Don't repr() the description as it is not needed
- Fix stdin only showing a max of 32 lines

Additions:
- Adds additinal PARAMETER_ALIASES for QOL
- Adds parameter to control "test squashing"
    - If `squash_repeated` is True (the default), then tets that produce the same output are "squashed"
    - If `show_squashed_input` is set to True, then stdin is still shown for squashed tests
    - If `show_squashed_reproduce_command` is set to True, then the reproduce command is still shown for squashed tests
- Add the ability for --generate_expected_output to generate multiline strings

Updates:
- Update .gitignore to better ignore files created by IEDs or OSs