### PR TITLE
Fix stray output with out-of-order error

### DIFF
--- a/explain_output_differences.py
+++ b/explain_output_differences.py
@@ -126,7 +126,7 @@ def explain_output_differences(
         and sorted(canonical_expected_lines) == sorted(canonical_actual_lines)
     ):
         explanation += colored(
-            f"\nYour program produced the correct {name} lines but in the wrong order.\n"
+            f"\nYour program produced the correct {name} lines but in the wrong order.\n",
             "red",
         )
 


### PR DESCRIPTION
A missing comma led to implicit string concatenation in the error message for when the output lines are correct but in the wrong order:
```
$ cat tests.txt
files=prog.c
1 expected_stdout='1\n2\n3\n'
$ cat prog.c
#include <stdio.h>
int main(void) {
    printf("3\n2\n1\n");
}
$ autotest -a .
[...]
Test 1 (prog) - failed (Incorrect output)

Your program produced the correct output lines but in the wrong order.
redYour program produced these 3 lines of output:
[...]
```