### PR TITLE
Prevent crash in helper.py when program outputs null bytes

### DIFF
--- a/helper.py
+++ b/helper.py
@@ -53,7 +53,7 @@ def run_helper(tests, parameters, args):
         "autotest_directory": args.autotest_directory,
     }
     for k, v in helper_info.items():
-        os.environ["HELPER_" + k.upper()] = v
+        os.environ["HELPER_" + k.upper()] = v.replace('\x00', '\\x00')
     os.environ["HELPER_JSON"] = json.dumps(helper_info, separators=(",", ":"))
 
     if args.debug:


### PR DESCRIPTION
If the program being tested outputs a null byte to stdout autotest crashes with
```
Traceback (most recent call last):
  File "/usr/local/share/autotest/autotest.py", line 41, in main
    sys.exit(run_autotest())
             ^^^^^^^^^^^^^^
  File "/usr/local/share/autotest/autotest.py", line 111, in run_autotest
    run_helper(tests, parameters, args)
  File "/usr/local/extrafiles/share/autotest/helper.py", line 56, in run_helper
    os.environ["HELPER_" + k.upper()] = v
    ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen os>", line 685, in __setitem__
ValueError: embedded null byte
```
This is because the stdout of the program is passed to the helper via an environment variable, which does not permit embedding null bytes. Similar issues occur with the stdin/stderr/expected_stdout/source.

This PR replaces the null bytes with `\x00`, which I assume the LLM can still make sense of.