### PR TITLE
Add aggressive_ignore_whitespace parameter for output comparison

### DIFF
--- a/parameter_descriptions.py
+++ b/parameter_descriptions.py
@@ -982,6 +982,14 @@ PARAMETER_LIST += [
     ),
     "### Parameters controlling information printed about test",
     Parameter(
+        "aggressive_ignore_whitespace",
+        default=False,
+        description="""
+            Ignore **ALL** whitespace (spaces and tabs, including those inside lines) when comparing actual & expected output.<br>
+            This ensures stricter whitespace removal for comparison.
+        """,
+    ),
+    Parameter(
         "colorize_output",
         default=lambda parameters: sys.stdout.isatty(),
         required_type=bool,

--- a/run_test.py
+++ b/run_test.py
@@ -199,6 +199,8 @@ class _Test:
             if self.debug:
                 print(f"after filter s='{s}'")
 
+        if self.parameters["aggressive_ignore_whitespace"]:
+            s = re.sub(r'[\t ]+', '', s)
         if self.parameters["ignore_case"]:
             s = s.lower()
         s = s.translate(self.canonical_translator)
@@ -207,6 +209,7 @@ class _Test:
             s = re.sub(r"^\n+", "", s)
         if self.parameters["ignore_trailing_whitespace"]:
             s = re.sub(r"[ \t]+\n", "\n", s)
+
         if self.debug > 1:
             print(f"make_string_canonical('{raw_str}') -> '{s}'")
         return s


### PR DESCRIPTION
I am a freshman and was stuck on an auto-test issue caused by a whitespace mismatch for an hour. To address this, I made this pull request.  

This pull request introduces a new parameter called `aggressive_ignore_whitespace` for output comparison.

### Local Testing Results

I have tested the changes locally, and here are the results:

```plaintext
╭─aoba@LMFuture-Laptop ~/Downloads  
╰─➤  python3 ~/Projects/autotest/autotest.py -a .                                   127 ↵
gcc -Wall -o test test.c
Test test1 (aggressive_ignore_whitespace=False (default)) - passed
Test test2 (aggressive_ignore_whitespace=True) - passed
Test test3 (aggressive_ignore_whitespace=True and ignore_trailing_whitespace=True) - passed
Test test4 (aggressive_ignore_whitespace=False and ignore_trailing_whitespace=True (original)) - passed
4 tests passed 0 tests failed
```

---

### `test.c`

Here is the sample `test.c` file used for testing:

```c
#include <stdio.h>

int main() {
    printf("Hello   \t  World!  \n");
    printf("Line 2  with space. \n");
    printf("NoSpaceLine3.\n");
    return 0;
}
```

---

### `tests.txt` Configuration

Below is the `tests.txt` configuration file that defines the test cases:

```plaintext
files=test.c
default_compilers = {'c' : [['gcc', '-Wall', '-o', '%']]}

# Test aggressive_ignore_whitespace was disabled
test1 command="./test" expected_stdout="Hello   \t  World!  \nLine 2  with space. \nNoSpaceLine3.\n"
test1 description="aggressive_ignore_whitespace=False (default)"

# Test aggressive_ignore_whitespace was enabled
test2 aggressive_ignore_whitespace=True command="./test" expected_stdout="HelloWorld!\nLine2withspace.\nNoSpaceLine3.\n"
test2 description="aggressive_ignore_whitespace=True"

# Test aggressive_ignore_whitespace=True and ignore_trailing_whitespace=True were both enabled
test3 aggressive_ignore_whitespace=True ignore_trailing_whitespace=True command="./test" expected_stdout="HelloWorld!\nLine2withspace.\nNoSpaceLine3.\n"
test3 description="aggressive_ignore_whitespace=True and ignore_trailing_whitespace=True"

# Test aggressive_ignore_whitespace=False and ignore_trailing_whitespace=True were both enabled
test4 ignore_trailing_whitespace=True command="./test" expected_stdout="Hello   \t  World!\nLine 2  with space.\nNoSpaceLine3.\n"
test4 description="aggressive_ignore_whitespace=False and ignore_trailing_whitespace=True (original)"
```